### PR TITLE
NIN-103 fix: remove alerts and orchestration paths from project yml

### DIFF
--- a/src/dbt_project.yml
+++ b/src/dbt_project.yml
@@ -17,10 +17,6 @@ test-paths: ['tests']
 macro-paths: ['macros']
 snapshot-paths: ['snapshots']
 
-# Y42 specific folders
-alert-paths: ['alerts']
-orchestration-paths: ['orchestrations']
-
 target-path: 'target' # directory which will store compiled SQL files
 clean-targets: # directories to be removed by `dbt clean`
   - 'target'


### PR DESCRIPTION
remove alerts and orchestration files from dbt_project.yml. 

fixes `Additional properties are not allowed ('alert-paths', 'orchestration-paths' were unexpected)` error.